### PR TITLE
Refactor plugin to modular WordPress structure

### DIFF
--- a/hide-title-post-page.php
+++ b/hide-title-post-page.php
@@ -2,82 +2,22 @@
 /**
  * Plugin Name: Hide Title Post Page
  * Description: Allows authors to hide the title tag on single pages and posts via the edit post screen.
- * Version: 1.0
+ * Version: 1.1
  * Author: Mirza Rizvi Amin
+ * Text Domain: hide-title-post-page
  */
 
-class Hide_Title_Plugin {
-
-    public function __construct() {
-        add_action('add_meta_boxes', array($this, 'add_meta_boxes'));
-        add_action('save_post', array($this, 'save_hide_title_meta_box'));
-        add_filter('the_title', array($this, 'hide_title'), 10, 2);
-    }
-
-    public function add_meta_boxes() {
-        add_meta_box(
-            'hide_title_meta_box',
-            'Hide Title',
-            array($this, 'hide_title_meta_box_callback'),
-            'post',
-            'side',
-            'default'
-        );
-        add_meta_box(
-            'hide_title_meta_box',
-            'Hide Title',
-            array($this, 'hide_title_meta_box_callback'),
-            'page',
-            'side',
-            'default'
-        );
-    }
-
-    public function hide_title_meta_box_callback($post) {
-        $hide_title = get_post_meta($post->ID, 'hide_title', true);
-        ?>
-        <?php wp_nonce_field('hide_title_nonce_action', 'hide_title_nonce'); ?>
-        <label for="hide_title">
-            <input type="checkbox" name="hide_title" id="hide_title" value="1" <?php checked(1, $hide_title, true); ?>>
-            Hide the title tag on this post or page
-        </label>
-        <?php
-    }
-
-    public function save_hide_title_meta_box($post_id) {
-        if (!isset($_POST['hide_title_nonce']) ||
-            !wp_verify_nonce($_POST['hide_title_nonce'], 'hide_title_nonce_action')) {
-            return;
-        }
-        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
-            return;
-        }
-        if (!current_user_can('edit_post', $post_id)) {
-            return;
-        }
-        if (isset($_POST['hide_title'])) {
-            update_post_meta($post_id, 'hide_title', 1);
-        } else {
-            delete_post_meta($post_id, 'hide_title');
-        }
-    }
-
-    public function hide_title($title, $id = null) {
-        if (is_admin()) {
-            return $title;
-        }
-
-        $post_id = $id ? $id : get_the_ID();
-
-        if (is_single() || is_page()) {
-            $hide_title = get_post_meta($post_id, 'hide_title', true);
-            if ($hide_title) {
-                return '';
-            }
-        }
-
-        return $title;
-    }
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
 }
 
-$hide_title_plugin = new Hide_Title_Plugin();
+define( 'HTPP_PATH', plugin_dir_path( __FILE__ ) );
+define( 'HTPP_URL', plugin_dir_url( __FILE__ ) );
+
+require_once HTPP_PATH . 'includes/class-hide-title-plugin.php';
+
+function htpp_run_plugin() {
+    $plugin = new Hide_Title_Plugin();
+    $plugin->run();
+}
+add_action( 'plugins_loaded', 'htpp_run_plugin' );

--- a/includes/admin/class-meta-box.php
+++ b/includes/admin/class-meta-box.php
@@ -1,0 +1,51 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Hide_Title_Meta_Box {
+
+    public function register() {
+        add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
+        add_action( 'save_post', array( $this, 'save_meta_box' ) );
+    }
+
+    public function add_meta_boxes() {
+        add_meta_box(
+            'hide_title_meta_box',
+            __( 'Hide Title', 'hide-title-post-page' ),
+            array( $this, 'render_meta_box' ),
+            array( 'post', 'page' ),
+            'side',
+            'default'
+        );
+    }
+
+    public function render_meta_box( $post ) {
+        $hide_title = get_post_meta( $post->ID, 'hide_title', true );
+        wp_nonce_field( 'hide_title_nonce_action', 'hide_title_nonce' );
+        ?>
+        <label for="hide_title">
+            <input type="checkbox" name="hide_title" id="hide_title" value="1" <?php checked( 1, $hide_title, true ); ?>>
+            <?php esc_html_e( 'Hide the title tag on this post or page', 'hide-title-post-page' ); ?>
+        </label>
+        <?php
+    }
+
+    public function save_meta_box( $post_id ) {
+        if ( ! isset( $_POST['hide_title_nonce'] ) || ! wp_verify_nonce( $_POST['hide_title_nonce'], 'hide_title_nonce_action' ) ) {
+            return;
+        }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
+            return;
+        }
+        if ( isset( $_POST['hide_title'] ) ) {
+            update_post_meta( $post_id, 'hide_title', 1 );
+        } else {
+            delete_post_meta( $post_id, 'hide_title' );
+        }
+    }
+}

--- a/includes/class-hide-title-plugin.php
+++ b/includes/class-hide-title-plugin.php
@@ -1,0 +1,35 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Hide_Title_Plugin {
+    private $meta_box;
+
+    public function __construct() {
+        require_once HTPP_PATH . 'includes/admin/class-meta-box.php';
+        $this->meta_box = new Hide_Title_Meta_Box();
+    }
+
+    public function run() {
+        $this->meta_box->register();
+        add_filter( 'the_title', array( $this, 'filter_title' ), 10, 2 );
+    }
+
+    public function filter_title( $title, $id = null ) {
+        if ( is_admin() ) {
+            return $title;
+        }
+
+        $post_id = $id ? $id : get_the_ID();
+
+        if ( is_singular() ) {
+            $hide = get_post_meta( $post_id, 'hide_title', true );
+            if ( $hide ) {
+                return '';
+            }
+        }
+
+        return $title;
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 5.0
 Tested up to: 6.5
 Requires PHP: 7.0
 Author: Mirza Rizvi Amin
-Stable tag: 1.0
+Stable tag: 1.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -26,6 +26,8 @@ The Hide Title Post Page plugin adds a lightweight meta box to posts and pages t
 1. Hide Title meta box in the post edit screen.
 
 == Changelog ==
+1.1
+- Refactored the plugin structure into modular classes and moved files to the `includes` directory.
 1.0
 - Initial release.
 


### PR DESCRIPTION
## Summary
- reorganize plugin using a modular architecture
- move logic to `includes` directory with a dedicated meta box class
- update main plugin file to load new modules
- bump version and update readme

## Testing
- `php -l hide-title-post-page.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2590b1d48325a61510952d1a32e0