### PR TITLE
Add documentation and PHPDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Hide Title Post Page
+
+This repository contains the source code for the **Hide Title Post Page** WordPress plugin. The plugin allows authors to hide the title on individual posts or pages through a simple meta box in the editor.
+
+- **Version:** 1.1
+- **License:** GPLv2 or later
+
+## Features
+
+- Adds a "Hide Title" meta box to post and page edit screens.
+- Stores a per‑post setting in post meta when the checkbox is selected.
+- Filters the post title on the front end so that the tag is removed when the setting is enabled.
+
+## Installation
+
+1. Download or clone this repository into your site's `wp-content/plugins/` directory.
+2. Activate the plugin from the **Plugins** screen in the WordPress admin.
+3. Edit a post or page and look for the **Hide Title** meta box in the sidebar.
+4. Check the box and save the post to hide its title on the front end.
+
+## Usage Example
+
+```php
+// The plugin works automatically after activation.
+// When the checkbox in the meta box is selected for a post or page,
+// the `<h1>` element (or whatever the theme uses for the title) will be removed
+// in the post's single view.
+```
+
+For more information about the plugin structure and the available classes and functions, see [docs/developer-guide.md](docs/developer-guide.md).
+

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,71 @@
+# Developer Guide
+
+This document describes the structure of the plugin and the main classes and functions that make it work.
+
+## Plugin Bootstrap
+
+`hide-title-post-page.php` is the main plugin file. It defines constants for the plugin path and URL, loads the main class, and registers the `htpp_run_plugin` function on the `plugins_loaded` hook.
+
+````php
+// hide-title-post-page.php
+require_once HTPP_PATH . 'includes/class-hide-title-plugin.php';
+
+function htpp_run_plugin() {
+    $plugin = new Hide_Title_Plugin();
+    $plugin->run();
+}
+add_action( 'plugins_loaded', 'htpp_run_plugin' );
+````
+
+## `Hide_Title_Plugin`
+
+Located in `includes/class-hide-title-plugin.php`, this class orchestrates the plugin by registering the meta box and filtering titles on the front end.
+
+### Key Methods
+
+- `__construct()` – Loads the `Hide_Title_Meta_Box` class.
+- `run()` – Hooks the meta box into WordPress and adds a filter to modify the post title output.
+- `filter_title( $title, $id = null )` – Checks the post meta and returns an empty string if the title should be hidden.
+
+````php
+public function filter_title( $title, $id = null ) {
+    if ( is_admin() ) {
+        return $title;
+    }
+
+    $post_id = $id ? $id : get_the_ID();
+
+    if ( is_singular() ) {
+        $hide = get_post_meta( $post_id, 'hide_title', true );
+        if ( $hide ) {
+            return '';
+        }
+    }
+
+    return $title;
+}
+````
+
+## `Hide_Title_Meta_Box`
+
+Defined in `includes/admin/class-meta-box.php`, this class is responsible for rendering and saving the meta box.
+
+### Hooks
+
+- `add_meta_boxes` – Registers the meta box for posts and pages.
+- `save_post` – Saves the state of the checkbox to post meta.
+
+### Usage
+
+1. When editing a post or page, the meta box labeled **Hide Title** appears in the sidebar.
+2. Checking the box stores a `hide_title` value of `1` in the post's metadata.
+3. The `Hide_Title_Plugin::filter_title` method checks this value and removes the title from the front end when set.
+
+## Example Scenario
+
+To hide the title on a specific page:
+
+1. Activate the plugin.
+2. Navigate to **Pages > Add New** (or edit an existing page).
+3. In the **Hide Title** box, tick the checkbox and publish/update the page.
+4. View the page on the front end—the title will no longer be displayed.

--- a/hide-title-post-page.php
+++ b/hide-title-post-page.php
@@ -16,6 +16,14 @@ define( 'HTPP_URL', plugin_dir_url( __FILE__ ) );
 
 require_once HTPP_PATH . 'includes/class-hide-title-plugin.php';
 
+/**
+ * Bootstrap the Hide Title Post Page plugin.
+ *
+ * Creates an instance of the main plugin class and executes it after all
+ * other plugins have loaded.
+ *
+ * @return void
+ */
 function htpp_run_plugin() {
     $plugin = new Hide_Title_Plugin();
     $plugin->run();

--- a/includes/admin/class-meta-box.php
+++ b/includes/admin/class-meta-box.php
@@ -3,13 +3,26 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Registers and renders the Hide Title meta box.
+ */
 class Hide_Title_Meta_Box {
 
+    /**
+     * Hook the meta box and save actions into WordPress.
+     *
+     * @return void
+     */
     public function register() {
         add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
         add_action( 'save_post', array( $this, 'save_meta_box' ) );
     }
 
+    /**
+     * Add the meta box to supported post types.
+     *
+     * @return void
+     */
     public function add_meta_boxes() {
         add_meta_box(
             'hide_title_meta_box',
@@ -21,6 +34,12 @@ class Hide_Title_Meta_Box {
         );
     }
 
+    /**
+     * Output the meta box markup.
+     *
+     * @param WP_Post $post Current post object.
+     * @return void
+     */
     public function render_meta_box( $post ) {
         $hide_title = get_post_meta( $post->ID, 'hide_title', true );
         wp_nonce_field( 'hide_title_nonce_action', 'hide_title_nonce' );
@@ -32,6 +51,12 @@ class Hide_Title_Meta_Box {
         <?php
     }
 
+    /**
+     * Persist the meta box setting when the post is saved.
+     *
+     * @param int $post_id Post ID being saved.
+     * @return void
+     */
     public function save_meta_box( $post_id ) {
         if ( ! isset( $_POST['hide_title_nonce'] ) || ! wp_verify_nonce( $_POST['hide_title_nonce'], 'hide_title_nonce_action' ) ) {
             return;

--- a/includes/class-hide-title-plugin.php
+++ b/includes/class-hide-title-plugin.php
@@ -3,19 +3,37 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Main controller for the Hide Title Post Page plugin.
+ */
 class Hide_Title_Plugin {
     private $meta_box;
 
+    /**
+     * Instantiate dependencies.
+     */
     public function __construct() {
         require_once HTPP_PATH . 'includes/admin/class-meta-box.php';
         $this->meta_box = new Hide_Title_Meta_Box();
     }
 
+    /**
+     * Register hooks for the plugin.
+     *
+     * @return void
+     */
     public function run() {
         $this->meta_box->register();
         add_filter( 'the_title', array( $this, 'filter_title' ), 10, 2 );
     }
 
+    /**
+     * Remove the title on the front end when requested.
+     *
+     * @param string $title The original post title.
+     * @param int|null $id  Optional post ID.
+     * @return string The filtered title.
+     */
     public function filter_title( $title, $id = null ) {
         if ( is_admin() ) {
             return $title;


### PR DESCRIPTION
## Summary
- add README with plugin overview and usage
- document plugin structure in `docs/developer-guide.md`
- include PHPDoc comments for core classes and bootstrap function

## Testing
- `php -l hide-title-post-page.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cdef246bc8325b25b53a679178299