### PR TITLE
Add translation loader and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains the source code for the **Hide Title Post Page** WordPr
 - Adds a "Hide Title" meta box to post and page edit screens.
 - Stores a per‑post setting in post meta when the checkbox is selected.
 - Filters the post title on the front end so that the tag is removed when the setting is enabled.
+- Translation files are located in the `languages/` directory.
 
 ## Installation
 

--- a/hide-title-post-page.php
+++ b/hide-title-post-page.php
@@ -17,6 +17,16 @@ define( 'HTPP_URL', plugin_dir_url( __FILE__ ) );
 require_once HTPP_PATH . 'includes/class-hide-title-plugin.php';
 
 /**
+ * Load plugin translation files.
+ *
+ * @return void
+ */
+function htpp_load_textdomain() {
+    load_plugin_textdomain( 'hide-title-post-page', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'plugins_loaded', 'htpp_load_textdomain' );
+
+/**
  * Bootstrap the Hide Title Post Page plugin.
  *
  * Creates an instance of the main plugin class and executes it after all
@@ -28,4 +38,4 @@ function htpp_run_plugin() {
     $plugin = new Hide_Title_Plugin();
     $plugin->run();
 }
-add_action( 'plugins_loaded', 'htpp_run_plugin' );
+add_action( 'plugins_loaded', 'htpp_run_plugin', 20 );


### PR DESCRIPTION
## Summary
- load the plugin's textdomain
- schedule plugin bootstrap after loading translations
- document the new `languages/` directory

## Testing
- `php -l hide-title-post-page.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cefed28ac8325af3a8cbb60f771ac